### PR TITLE
Add persistent homology notebook with GUDHI

### DIFF
--- a/notebooks/05_persistent_homology.ipynb
+++ b/notebooks/05_persistent_homology.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# **Persistent Homology on Football Passing Networks**\n",
+    "\n",
+    "## **Objective**\n",
+    "Demonstrate how persistent homology reveals higher-order structure in football passing networks using the GUDHI library.\n",
+    "\n",
+    "## **Steps**\n",
+    "1. Create an example passing network\n",
+    "2. Build a Rips complex from shortest-path distances\n",
+    "3. Compute and visualize persistent homology\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## **1. Environment Setup**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import networkx as nx\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import gudhi as gd\n",
+    "import gudhi.plot as gplt\n",
+    "\n",
+    "plt.style.use('seaborn-v0_8')\n",
+    "RANDOM_STATE = 42\n",
+    "np.random.seed(RANDOM_STATE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-3",
+   "metadata": {},
+   "source": [
+    "## **2. Create Example Passing Network**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate a synthetic passing network\n",
+    "G = nx.connected_watts_strogatz_graph(11, k=4, p=0.3, seed=RANDOM_STATE)\n",
+    "pos = nx.spring_layout(G, seed=RANDOM_STATE)\n",
+    "\n",
+    "plt.figure(figsize=(4,4))\n",
+    "nx.draw_networkx(G, pos=pos, node_color='skyblue', edge_color='gray', with_labels=True)\n",
+    "plt.title('Synthetic Passing Network')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-5",
+   "metadata": {},
+   "source": [
+    "## **3. Compute Persistent Homology with GUDHI**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute shortest-path distance matrix\n",
+    "lengths = dict(nx.all_pairs_shortest_path_length(G))\n",
+    "nodes = list(G.nodes())\n",
+    "n = len(nodes)\n",
+    "dist_matrix = np.zeros((n, n))\n",
+    "for i, u in enumerate(nodes):\n",
+    "    for j, v in enumerate(nodes):\n",
+    "        dist_matrix[i, j] = lengths[u][v]\n",
+    "\n",
+    "# build Rips complex and compute persistence\n",
+    "rips = gd.RipsComplex(distance_matrix=dist_matrix)\n",
+    "simplex_tree = rips.create_simplex_tree(max_dimension=2)\n",
+    "diag = simplex_tree.persistence()\n",
+    "\n",
+    "# plot persistence diagram\n",
+    "gplt.plot_persistence_diagram(diag)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/persistent_homology.py
+++ b/persistent_homology.py
@@ -1,0 +1,82 @@
+"""Utilities for analyzing football networks with persistent homology.
+
+This script demonstrates how to compute persistent homology on a complex
+network using the ripser library. It converts a ``networkx`` graph into a
+pairwise distance matrix based on shortest path lengths, then feeds the
+resulting distances to ``ripser`` to obtain persistence diagrams. A simple
+example graph is provided when the script is executed directly.
+
+Dependencies
+------------
+- networkx
+- ripser
+- persim
+- matplotlib
+- numpy
+
+Because these packages are not part of the standard library, they must be
+installed separately before running the script.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import networkx as nx
+from ripser import ripser
+from persim import plot_diagrams
+import matplotlib.pyplot as plt
+
+
+def graph_to_distance_matrix(graph: nx.Graph) -> np.ndarray:
+    """Return a dense matrix of shortest path lengths for ``graph``.
+
+    Parameters
+    ----------
+    graph:
+        The input ``networkx`` graph. The graph should be connected; otherwise
+        infinite distances will appear between disconnected components.
+
+    Returns
+    -------
+    numpy.ndarray
+        A square matrix where entry ``(i, j)`` contains the shortest path
+        length between node ``i`` and node ``j``.
+    """
+
+    nodes = list(graph.nodes)
+    size = len(nodes)
+    dist = np.full((size, size), np.inf, dtype=float)
+    for i, u in enumerate(nodes):
+        dist[i, i] = 0.0
+        lengths = nx.single_source_shortest_path_length(graph, u)
+        for v, d in lengths.items():
+            j = nodes.index(v)
+            dist[i, j] = float(d)
+    return dist
+
+
+def persistent_homology(graph: nx.Graph):
+    """Compute persistence diagrams of ``graph`` using its clique complex."""
+    dist = graph_to_distance_matrix(graph)
+    n = dist.shape[0]
+    condensed = dist[np.triu_indices(n, k=1)]
+    return ripser(condensed, distance_matrix=True)["dgms"]
+
+
+def example_graph(num_nodes: int = 10, p: float = 0.4) -> nx.Graph:
+    """Generate a connected Erdős–Rényi graph for demonstration."""
+    graph = nx.erdos_renyi_graph(num_nodes, p, seed=0)
+    while not nx.is_connected(graph):
+        graph = nx.erdos_renyi_graph(num_nodes, p)
+    return graph
+
+
+def plot_diagrams_from_graph(graph: nx.Graph) -> None:
+    """Plot persistence diagrams for ``graph``."""
+    diagrams = persistent_homology(graph)
+    plot_diagrams(diagrams, show=True)
+
+
+if __name__ == "__main__":
+    demo_graph = example_graph()
+    plot_diagrams_from_graph(demo_graph)


### PR DESCRIPTION
## Summary
- add notebook demonstrating persistent homology on passing networks using GUDHI

## Testing
- `python -m py_compile persistent_homology.py`
- `jupyter nbconvert --to notebook --execute notebooks/05_persistent_homology.ipynb --output /tmp/05_persistent_homology_out.ipynb` *(fails: command not found: jupyter)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a87e2836f88325b4933549a50f988e